### PR TITLE
Setup Vite build and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+dist
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# goki_care
+# GokiCare
+
+React + Tailwind CSS で作られたミニアプリです。Vite を使ってビルドし、GitHub Pages へデプロイできるように GitHub Actions のワークフローも用意しています。
+
+## 開発環境の使い方
+
+```bash
+npm install
+npm run dev
+```
+
+## ビルド
+
+```bash
+npm run build
+```
+
+`dist/` に静的ファイルが出力されます。
+
+## デプロイ（GitHub Actions）
+
+`main` ブランチへ push すると `.github/workflows/deploy.yml` が走り、ビルド成果物が GitHub Pages に自動公開されます。手動実行したい場合は GitHub の Actions タブから `Run workflow` を選択してください。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GokiCare</title>
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "goki-care",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "vite": "^5.0.8"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 // GokiCare – 子ども向け（だけど大人にも効く）ごほうび付き強化版
 // 単一ファイルReact。Tailwind前提。localStorageで進捗＆報酬を保存。
@@ -79,7 +79,10 @@ function BreathingGuide({ running }) {
   return (
     <div className="flex flex-col items-center gap-3">
       <div className="w-40 h-40 rounded-full border-2 border-neutral-300 grid place-items-center">
-        <div className="transition-all duration-300 ease-linear" style={{ width: `${60 + 60*ratio}%`, height: `${60 + 60*ratio}%`}}>
+        <div
+          className="transition-all duration-300 ease-linear"
+          style={{ width: `${60 + 60*ratio}%`, height: `${60 + 60*ratio}%` }}
+        >
           <div className="w-full h-full rounded-full bg-neutral-300/60" />
         </div>
       </div>
@@ -127,7 +130,6 @@ export default function GokiCare() {
   const [blur, setBlur] = useState(saved.blur ?? 12);
   const [dim, setDim] = useState(saved.dim ?? 0.2);
   const [panic, setPanic] = useState(false);
-  const [breath, setBreath] = useState(true);
 
   // ゲーム化要素
   const [coins, setCoins] = useState(saved.coins || 0);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f5f5;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './'
+});


### PR DESCRIPTION
## Summary
- scaffolded a Vite + Tailwind toolchain so the React app can build to static assets
- added a GitHub Actions workflow that builds the site and deploys it to GitHub Pages on pushes to main

## Testing
- not run (npm registry access returns 403 in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3f9c561288322b0086e7b1aac174f