### PR TITLE
Add animated roach sweep during hunts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,44 @@ body {
 * {
   box-sizing: border-box;
 }
+
+.roach-sweep {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation-name: roach-scamper;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+}
+
+@keyframes roach-scamper {
+  0% {
+    transform: translate3d(var(--roach-start-x, -240px), var(--roach-y-start, 0px), 0)
+      rotate(var(--roach-tilt-start, -8deg));
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  50% {
+    transform: translate3d(var(--roach-mid-x, 0px), var(--roach-y-mid, 0px), 0)
+      rotate(var(--roach-tilt-mid, 0deg));
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--roach-end-x, 260px), var(--roach-y-end, 0px), 0)
+      rotate(var(--roach-tilt-end, 8deg));
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .roach-sweep {
+    animation: none !important;
+    transform: translate3d(0, 0, 0) !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a motion profile so the hunt screen cockroach sweeps horizontally while waiting for a tap
- wrap the SVG artwork in an animated group with randomized timing seeded by encounter count
- create keyframes and reduced-motion styles so the movement is smooth but still accessible

## Testing
- npm run build *(fails: vite not found in this execution environment because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d412c4c9a48322bc05a1840b534734