### PR TITLE
Add motion override to re-enable animations on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,16 @@ button {
   will-change: transform;
 }
 
+.encounter-object.reduce-motion {
+  animation: none !important;
+  opacity: 1;
+}
+
+.touch-target.reduce-motion {
+  transition: none;
+}
+
+
 .touch-target {
   width: 84px;
   height: 84px;
@@ -292,11 +302,12 @@ button {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .encounter-object {
+  body:not(.motion-override-animated) .encounter-object {
     animation: none !important;
     opacity: 1;
   }
-  .touch-target {
+
+  body:not(.motion-override-animated) .touch-target {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- add a manual override that lets players re-enable full animations even when the OS requests reduced motion
- wire the override through the floating objects so objects regain movement when the override is active
- adjust styles so reduced-motion handling is governed by the override and respects the body-level flag

## Testing
- npm run build *(fails: vite not found because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d528eede7483228aa35c83611b5763