### PR TITLE
Enable enemy spawns from both sides

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -228,7 +228,13 @@ function FloatingObject({ object, difficulty, onTap, reduceMotion }) {
     animationDuration: `${object.duration}ms`,
   };
 
-  const containerClassName = reduceMotion ? 'encounter-object reduce-motion' : 'encounter-object';
+  const containerClassName = [
+    'encounter-object',
+    reduceMotion ? 'reduce-motion' : null,
+    reduceMotion ? null : `from-${object.direction}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
   const targetClassName = reduceMotion ? 'touch-target reduce-motion' : 'touch-target';
 
   if (reduceMotion) {
@@ -504,7 +510,8 @@ export default function App() {
         const scale = Math.random() * 0.4 + 0.8;
         const variant = variantPool[randomBetween(0, variantPool.length - 1)];
         const staticLeft = randomBetween(12, 88);
-        const newObject = { id, isRoach, duration, top, scale, variant, staticLeft };
+        const direction = Math.random() < 0.5 ? 'left' : 'right';
+        const newObject = { id, isRoach, duration, top, scale, variant, staticLeft, direction };
         setActiveObjects((prev) => [...prev, newObject]);
         const timeout = setTimeout(() => {
           setActiveObjects((prev) => prev.filter((item) => item.id !== id));

--- a/src/index.css
+++ b/src/index.css
@@ -24,14 +24,22 @@ button {
 
 .encounter-object {
   position: absolute;
-  left: -28vw;
   top: 50%;
   transform: translateY(-50%);
-  animation-name: scurryAcross;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
   animation-duration: 5s;
   will-change: transform;
+}
+
+.encounter-object.from-left {
+  left: -28vw;
+  animation-name: scurryAcrossFromLeft;
+}
+
+.encounter-object.from-right {
+  right: -28vw;
+  animation-name: scurryAcrossFromRight;
 }
 
 .encounter-object.reduce-motion {
@@ -283,7 +291,7 @@ button {
   box-shadow: 0 6px 16px rgba(148, 163, 184, 0.4);
 }
 
-@keyframes scurryAcross {
+@keyframes scurryAcrossFromLeft {
   0% {
     transform: translate(-20vw, 0);
     opacity: 0;
@@ -297,6 +305,24 @@ button {
   }
   100% {
     transform: translate(110vw, 0);
+    opacity: 0;
+  }
+}
+
+@keyframes scurryAcrossFromRight {
+  0% {
+    transform: translate(20vw, 0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  50% {
+    transform: translate(-45vw, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-110vw, 0);
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- add directional metadata to spawned encounter objects and choose left/right origins at random
- update floating object rendering to apply direction-specific classes when motion animations are enabled
- split encounter animation into left-to-right and right-to-left variants to support spawns from both sides

## Testing
- npm run build *(fails: `vite` command unavailable because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d54b6a04008322835c94139466065b