### PR TITLE
Implement stage-specific gameplay variants

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@ body {
     'Segoe UI', sans-serif;
   background: radial-gradient(circle at 20% 20%, #0f172a 0%, #020617 55%, #01010f 100%);
   color: #e2e8f0;
+  -webkit-tap-highlight-color: transparent;
 }
 
 button {
@@ -62,6 +63,7 @@ button {
   border: none;
   cursor: pointer;
   transition: transform 120ms ease, filter 120ms ease;
+  touch-action: manipulation;
 }
 
 .touch-target:active {
@@ -289,6 +291,232 @@ button {
   border-radius: 16px;
   background: linear-gradient(160deg, rgba(248, 250, 252, 0.95), rgba(191, 219, 254, 0.8));
   box-shadow: 0 6px 16px rgba(148, 163, 184, 0.4);
+}
+
+.stage-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(209, 250, 229, 0.5);
+  pointer-events: none;
+  padding: 0 1rem;
+}
+
+.stage-flash,
+.stage-shooter,
+.stage-saber {
+  position: absolute;
+  inset: 0;
+}
+
+.stage-flash {
+  display: block;
+}
+
+.flash-target {
+  position: absolute;
+  padding: 0;
+  border: none;
+  background: transparent;
+  animation-name: flashAppear;
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-in-out;
+  cursor: pointer;
+}
+
+.flash-target.reduce-motion {
+  animation: none;
+}
+
+@keyframes flashAppear {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.6);
+  }
+  45% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
+.stage-shooter {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  cursor: crosshair;
+  touch-action: manipulation;
+}
+
+.shooter-sky {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 20%, rgba(45, 212, 191, 0.12), transparent 70%);
+}
+
+.shooter-roach {
+  position: absolute;
+  top: -20%;
+  transform: translate(-50%, -50%) scale(0.8);
+  animation-name: descendRoach;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+  pointer-events: none;
+}
+
+.shooter-roach.reduce-motion {
+  animation: none;
+  top: 30% !important;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+@keyframes descendRoach {
+  0% {
+    top: -20%;
+    transform: translate(-50%, -50%) scale(0.8);
+  }
+  60% {
+    top: 48%;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    top: 110%;
+    transform: translate(-50%, -50%) scale(1.15);
+    opacity: 0;
+  }
+}
+
+.laser-beam {
+  position: absolute;
+  bottom: 80px;
+  width: 6px;
+  height: 0;
+  background: linear-gradient(180deg, rgba(190, 242, 100, 0.9), rgba(74, 222, 128, 0.65));
+  box-shadow: 0 0 16px rgba(74, 222, 128, 0.6);
+  border-radius: 999px;
+  transform: translateX(-50%);
+  animation: laserFire 0.5s ease-out forwards;
+  pointer-events: none;
+}
+
+@keyframes laserFire {
+  0% {
+    height: 0;
+    opacity: 0;
+  }
+  40% {
+    opacity: 1;
+  }
+  100% {
+    height: 140%;
+    opacity: 0;
+  }
+}
+
+.shooter-ship {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  width: 80px;
+  height: 64px;
+  transform: translateX(-50%);
+  background: radial-gradient(circle at 50% 20%, rgba(248, 250, 252, 0.9), rgba(134, 239, 172, 0.8));
+  clip-path: polygon(50% 0%, 88% 35%, 100% 100%, 0% 100%, 12% 35%);
+  box-shadow: 0 12px 30px rgba(16, 185, 129, 0.45);
+  pointer-events: none;
+}
+
+.stage-saber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.saber-enemy {
+  position: absolute;
+  top: -20%;
+  transform: translate(-50%, -50%) scale(0.5);
+  animation-name: approachEnemy;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
+  pointer-events: none;
+}
+
+.saber-enemy.strike-ready {
+  filter: drop-shadow(0 0 12px rgba(252, 211, 77, 0.55));
+}
+
+.saber-enemy.reduce-motion {
+  animation: none;
+  top: 50% !important;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+@keyframes approachEnemy {
+  0% {
+    top: -20%;
+    transform: translate(-50%, -50%) scale(0.4);
+    opacity: 0;
+  }
+  55% {
+    top: 48%;
+    transform: translate(-50%, -50%) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    top: 110%;
+    transform: translate(-50%, -50%) scale(1.3);
+    opacity: 0;
+  }
+}
+
+.saber-slash {
+  position: absolute;
+  inset: 0;
+  width: 8px;
+  margin: auto;
+  background: linear-gradient(180deg, rgba(253, 224, 71, 0.95), rgba(249, 115, 22, 0.6));
+  border-radius: 999px;
+  transform: rotate(-12deg) scaleY(0.2);
+  box-shadow: 0 0 24px rgba(253, 224, 71, 0.6);
+  animation: saberSlash 0.35s ease-out forwards;
+  pointer-events: none;
+}
+
+@keyframes saberSlash {
+  0% {
+    opacity: 0;
+    transform: rotate(-12deg) scaleY(0.1);
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(-12deg) scaleY(1.1);
+  }
+}
+
+.saber-hilt {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  width: 18px;
+  height: 82px;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.9), rgba(71, 85, 105, 0.8));
+  border-radius: 12px;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.65);
+  pointer-events: none;
 }
 
 @keyframes scurryAcrossFromLeft {


### PR DESCRIPTION
## Summary
- configure each stage with metadata to drive tailored instructions and mechanics
- implement flash, shooter, classic, and saber play areas with callbacks into the core loop
- extend styling for new animations and touch affordances so mobile renders match desktop

## Testing
- npm run build *(fails: vite is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d659d1fd0c8322a3301e7b91d0769e