### PR TITLE
Add header logo to landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import chabaneImage from './assets/chabane.png';
 import yamatoImage from './assets/yamato.png';
 import kuroImage from './assets/kuro.png';
 import wamonImage from './assets/wamon.png';
+import logoImage from '../logo.png';
 
 const MAX_LIVES = 3;
 const DEFAULT_KILL_TARGET = 10;
@@ -1101,7 +1102,12 @@ export default function App() {
   return (
     <div className={appClassName}>
       <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col gap-6 px-4 py-8">
-        <header className="space-y-2 text-center">
+        <header className="space-y-3 text-center">
+          <img
+            src={logoImage}
+            alt="GokiCare ロゴ"
+            className="mx-auto h-16 w-16 rounded-full border border-emerald-400/60 bg-slate-900/60 p-2 shadow-lg shadow-emerald-900/40"
+          />
           <p className="text-[11px] font-semibold uppercase tracking-[0.4em] text-emerald-300">ZUMI WARS</p>
           <h1 className="text-3xl font-black text-white sm:text-4xl">Gの逆襲</h1>
           <p className="text-xs text-emerald-100/80">


### PR DESCRIPTION
## Summary
- import the newly added logo asset into the main app
- render the logo above the title with styling so it appears at the top of the page header

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68d66eab2ad8832284a5b9c45c785e57