### PR TITLE
Remove drop shadow from title logo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1074,7 +1074,7 @@ export default function App() {
           <img
             src={logoImage}
             alt="GokiCare ロゴ"
-            className="mx-auto h-50 w-auto
+            className="hero-logo mx-auto h-50 w-auto"
           />
           <p className="text-xs text-emerald-100/80">
             この世に蔓延るGを一匹残らず駆逐するため、ジェダイの騎士ズミーが立ち上がる。フォースの力で銀河を守れ！

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,11 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
+.hero-logo {
+  filter: none !important;
+  box-shadow: none !important;
+}
+
 button {
   font-family: inherit;
 }


### PR DESCRIPTION
## Summary
- remove the remaining drop-shadow styling from the title logo by giving it a dedicated class
- add CSS overrides so the header logo renders without any shadow effects

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d888b3d88322aae4c55661113c7a