### PR TITLE
Update inferno super roach clear messages by stage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -975,6 +975,13 @@ function StageIntro({ stage, killTarget, onStart, difficulty }) {
   );
 }
 
+const SUPER_ROACH_STAGE_MESSAGES = {
+  1: '【す〜ぱ〜キラキラ☆うんこちゃん】を見つけたよ！ステージクリアだよ！',
+  2: '【す〜ぱ〜キラキラ☆うんこちゃん】を見つけたよ！ステージクリアだよ！そういう仕様だよ！',
+  3: '【す〜ぱ〜キラキラ☆うんこちゃん】を見つけたよ！ステージクリアだよ！そういう仕様だよ！疑問を持ってはいけないよ！',
+  4: 'うんこにばっかり頼ってないで実力で勝負しろよな。',
+};
+
 function StageClear({
   stage,
   isLastStage,
@@ -993,9 +1000,9 @@ function StageClear({
       <p className="mt-4 text-sm leading-relaxed text-emerald-100/90">
         ズミーはターゲットを{killTarget}匹撃破し、{stage.codename} セクターの制圧に成功した。
       </p>
-      {showSuperRoachMessage && isLastStage && (
+      {showSuperRoachMessage && SUPER_ROACH_STAGE_MESSAGES[stage.order] && (
         <p className="mt-4 rounded-2xl border border-amber-300/60 bg-amber-500/10 px-4 py-3 text-sm leading-relaxed text-amber-50">
-          【す〜ぱ〜キラキラ☆うんこちゃん】を捕まえたから、ゲームクリアです。そういう仕様です。ごちゃごちゃ言わないでください。
+          {SUPER_ROACH_STAGE_MESSAGES[stage.order]}
         </p>
       )}
       {isLastStage ? (


### PR DESCRIPTION
## Summary
- add a stage-specific message map for the inferno super roach clear dialog
- display the corresponding stage message when the super roach is defeated instead of the previous generic text

## Testing
- npm run build *(fails: vite not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80bd1c84483228b40fb2fd1e8c3c3