### PR TITLE
Adjust roach orientations for stage animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -229,10 +229,40 @@ function getStageRoachImage(stage, difficulty) {
   return stage.roachImage ?? null;
 }
 
-function StageRoach({ stage, difficulty, roachType = 'standard' }) {
+function getRoachOrientationClass(stage, direction) {
+  const stageId = stage?.id;
+
+  if (stageId === 'stage-2' || stageId === 'stage-4') {
+    return 'roach-orientation-down';
+  }
+
+  if (stageId === 'stage-3') {
+    if (direction === 'left') {
+      return 'roach-orientation-right';
+    }
+
+    if (direction === 'right') {
+      return 'roach-orientation-left';
+    }
+  }
+
+  return null;
+}
+
+function StageRoach({ stage, difficulty, roachType = 'standard', direction }) {
+  const orientationClass = getRoachOrientationClass(stage, direction);
+
   if (roachType === SUPER_ROACH.type) {
     return (
-      <div className="roach-graphic roach-super">
+      <div
+        className={[
+          'roach-graphic',
+          'roach-super',
+          orientationClass,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
         <img
           src={superRoachImage}
           alt={`${SUPER_ROACH.label}のターゲット`}
@@ -245,7 +275,11 @@ function StageRoach({ stage, difficulty, roachType = 'standard' }) {
   const roachImage = getStageRoachImage(stage, difficulty);
   if (roachImage) {
     return (
-      <div className="roach-graphic">
+      <div
+        className={['roach-graphic', orientationClass]
+          .filter(Boolean)
+          .join(' ')}
+      >
         <img
           src={roachImage}
           alt={stage?.roachAlt ?? `${stage?.species ?? 'G'}のターゲット`}
@@ -337,7 +371,12 @@ function ClassicFloatingObject({ stage, object, difficulty, onTap, reduceMotion 
         style={{ transform: `scale(${object.scale})` }}
       >
         {object.isRoach ? (
-          <StageRoach stage={stage} difficulty={difficulty} roachType={object.roachType} />
+          <StageRoach
+            stage={stage}
+            difficulty={difficulty}
+            roachType={object.roachType}
+            direction={object.direction}
+          />
         ) : (
           <DecoyGraphic variant={object.variant} />
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,18 @@ button {
   pointer-events: none;
 }
 
+.roach-graphic.roach-orientation-down {
+  transform: rotate(180deg);
+}
+
+.roach-graphic.roach-orientation-left {
+  transform: rotate(-90deg);
+}
+
+.roach-graphic.roach-orientation-right {
+  transform: rotate(90deg);
+}
+
 .roach-image {
   width: 72px;
   height: 72px;


### PR DESCRIPTION
## Summary
- add a helper to determine roach image orientation based on the stage and spawn direction
- rotate shooter and saber stage roaches downward and align classic stage roaches with their travel direction
- add CSS classes to apply the required orientation transforms

## Testing
- npm install *(fails: 403 Forbidden when downloading @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a970218832287202da931ac3198