### PR TITLE
Avoid rotating super roach graphic orientation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -250,15 +250,12 @@ function getRoachOrientationClass(stage, direction) {
 }
 
 function StageRoach({ stage, difficulty, roachType = 'standard', direction }) {
-  const orientationClass = getRoachOrientationClass(stage, direction);
-
   if (roachType === SUPER_ROACH.type) {
     return (
       <div
         className={[
           'roach-graphic',
           'roach-super',
-          orientationClass,
         ]
           .filter(Boolean)
           .join(' ')}
@@ -271,6 +268,8 @@ function StageRoach({ stage, difficulty, roachType = 'standard', direction }) {
       </div>
     );
   }
+
+  const orientationClass = getRoachOrientationClass(stage, direction);
 
   const roachImage = getStageRoachImage(stage, difficulty);
   if (roachImage) {


### PR DESCRIPTION
## Summary
- stop applying stage-based orientation classes to the super roach graphic so it keeps its original rotation

## Testing
- npm run build *(fails: missing Vite binary because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81d74b6fc8322875104e3885f1270